### PR TITLE
Add Skyward Paging Support

### DIFF
--- a/lib/bright.rb
+++ b/lib/bright.rb
@@ -13,6 +13,7 @@ require "bright/school"
 
 require "bright/connection"
 require "bright/response_collection"
+require "bright/cursor_response_collection"
 
 require "bright/sis_apis/base.rb"
 require "bright/sis_apis/tsis.rb"

--- a/lib/bright/cursor_response_collection.rb
+++ b/lib/bright/cursor_response_collection.rb
@@ -1,0 +1,45 @@
+class CursorResponseCollection < ResponseCollection
+
+  attr_accessor :collected_objects
+
+  def initialize(options = {})
+    @collected_objects = [options[:seed_page]].flatten
+    @per_page = options[:per_page].to_i
+    @load_more_call = options[:load_more_call]
+    @next_cursor = options[:next_cursor]
+  end
+
+  def each
+    while (!@next_cursor.blank?) do
+      objects_hsh = load_more_call.call(@next_cursor)
+      objects = objects_hsh[:objects]
+      @next_cursor = objects_hsh[:next_cursor]
+      objects.each do |obj|
+        yield obj
+      end
+      @collected_objects += objects
+    end
+  end
+
+  def last
+    self.to_a
+    return @collected_objects.last
+  end
+
+  def loaded_results
+    @collected_objects.flatten
+  end
+
+  def total
+    self.to_a
+    self.loaded_results.size
+  end
+
+  alias size total
+  alias length total
+
+  def empty?
+    self.to_a.empty?
+  end
+
+end

--- a/lib/bright/response_collection.rb
+++ b/lib/bright/response_collection.rb
@@ -1,11 +1,11 @@
 class ResponseCollection
   include Enumerable
-  
+
   attr_accessor :paged_objects
   attr_accessor :total
   attr_accessor :per_page
   attr_accessor :load_more_call
-  
+
   # seed_page, total, per_page, load_more_call
   def initialize(options = {})
     @paged_objects = {0 => options[:seed_page]}
@@ -14,7 +14,7 @@ class ResponseCollection
     @pages = @per_page > 0 ? (@total.to_f / @per_page.to_f).ceil : 0
     @load_more_call = options[:load_more_call]
   end
-  
+
   def each
     current_page = -1
     while (current_page += 1) < @pages do
@@ -33,7 +33,7 @@ class ResponseCollection
       @paged_objects[next_page_no] = next_page_thread.value if next_page_thread
     end
   end
-  
+
   def last
     last_page_no = @pages - 1
     if load_more_call and (last_page = @paged_objects[last_page_no]).nil?
@@ -41,11 +41,11 @@ class ResponseCollection
     end
     last_page.last
   end
-  
+
   def loaded_results
     @paged_objects.values.flatten
   end
-  
+
   alias size total
   alias length total
 

--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -233,7 +233,7 @@ module Bright
             self.schools_cache ||= {}
             if (attending_school = self.schools_cache[s["sourcedId"]]).nil?
               attending_school = self.get_school_by_api_id(s["sourcedId"])
-              self.schools_cache[s["sourcedId"]] = attending_school
+              self.schools_cache[attending_school.api_id] = attending_school
             end
           end
           student_data_hsh[:school] = attending_school


### PR DESCRIPTION
This pull request adds:
 * Support for APIs that use a cursor like Skyward
 * `#get_students` for Skyward
 * `#get_schools` for Skyward
 * internal cache for Skyward schools to avoid constant HTTP lookups