### PR TITLE
Connection Error Handling

### DIFF
--- a/lib/bright.rb
+++ b/lib/bright.rb
@@ -27,5 +27,7 @@ require "bright/sis_apis/skyward.rb"
 require "bright/sis_apis/bright_sis.rb"
 
 module Bright
-
+  class << self
+    attr_accessor :devmode
+  end
 end

--- a/lib/bright/errors.rb
+++ b/lib/bright/errors.rb
@@ -8,8 +8,13 @@ module Bright
     end
 
     def to_s
-      "Failed with #{response.code} #{response.message if response.respond_to?(:message)}"
+      "Failed with #{response.code} #{response.message if response.respond_to?(:message)}".strip
     end
+
+    def body
+      response.body
+    end
+
   end
 
   class UnknownAttributeError < NoMethodError


### PR DESCRIPTION
* Add a `Bright.devmode` to determine how much logging is going on
* Use the `handle_response` method to throw `Bright::ResponseError` errors when we have connection issues.  That way apps can catch / inspect what's going on.