### PR TITLE
Update for the possible case differences in IC installs for birthDate

### DIFF
--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -277,8 +277,8 @@ module Bright
       def get_demographic_information(api_id)
         demographic_hsh = {}
         demographics_params = self.request(:get, "demographics/#{api_id}")["demographics"]
-        unless demographics_params["birthdate"].blank?
-          demographic_hsh[:birth_date] = Date.parse(demographics_params["birthdate"]).to_s
+        unless (bday = demographics_params["birthdate"] || demographics_params["birthDate"]).blank?
+          demographic_hsh[:birth_date] = Date.parse(bday).to_s
         end
         unless demographics_params["sex"].to_s[0].blank?
           demographic_hsh[:gender] = demographics_params["sex"].to_s[0].upcase


### PR DESCRIPTION
At some point it appears the case may have changed in the response for birthdates.  It now appears `birthDate` is also possible as a key as well as `birthdate`.  This will check for them both.