### PR TITLE
Retry HTTP Calls on Server / Connection Errors

### DIFF
--- a/lib/bright/errors.rb
+++ b/lib/bright/errors.rb
@@ -15,6 +15,10 @@ module Bright
       response.body
     end
 
+    def server_error?
+      (500..599).include?(response&.code.to_i)
+    end
+
   end
 
   class UnknownAttributeError < NoMethodError


### PR DESCRIPTION
Adds an option for `retry_attempts` that is set with a default of 2 with back-off sleep if we get a network connection error or a 500 error from the server.