### PR TITLE
Move Retry Logic to Base

### DIFF
--- a/lib/bright/sis_apis/aeries.rb
+++ b/lib/bright/sis_apis/aeries.rb
@@ -2,29 +2,29 @@ module Bright
   module SisApi
     class Aeries < Base
       DATE_FORMAT = '%Y-%m-%dT%H:%M:%S'
-      
+
       @@description = "Connects to the Aeries API for accessing student information"
       @@doc_url = "http://www.aeries.com/downloads/docs.1234/TechnicalSpecs/Aeries_API_Documentation.pdf"
       @@api_version = ""
-      
+
       attr_accessor :connection_options
-      
+
       def initialize(options = {})
         self.connection_options = options[:connection] || {}
         # {
-        #   :certficate => "", 
+        #   :certficate => "",
         #   :uri => ""
         # }
       end
-      
+
       def get_student_by_api_id(api_id)
         get_students({:api_id => api_id, :limit => 1}).first
       end
-      
+
       def get_student(params)
         get_students(params.merge(:limit => 1)).first
       end
-      
+
       def get_students(params)
         if params.has_key?(:school) or params.has_key?(:school_api_id)
           school_api_id = params.delete(:school) || params.delete(:school_api_id)
@@ -32,7 +32,7 @@ module Bright
         else
           threads = []
           get_schools.each do |school|
-            threads << Thread.new do 
+            threads << Thread.new do
               get_students_by_school(school, params)
             end
           end
@@ -40,7 +40,7 @@ module Bright
         end
         filter_students_by_params(students, params)
       end
-      
+
       def get_students_by_school(school, params = {})
         school_api_id = school.is_a?(School) ? school.api_id : school
         if params.has_key?(:api_id)
@@ -53,21 +53,21 @@ module Bright
         students_response_hash = self.request(:get, path, self.map_student_search_params(params))
         students_response_hash.collect{|shsh| Student.new(convert_to_student_data(shsh))}
       end
-      
+
       def create_student(student)
         raise NotImplementedError
       end
-      
+
       def update_student(student)
         raise NotImplementedError
       end
-      
+
       def get_schools(params = {})
         schools_response_hash = self.request(:get, 'api/v2/schools', params)
-        
+
         schools_response_hash.collect{|h| School.new(convert_to_school_data(h))}
       end
-      
+
       def request(method, path, params = {})
         uri  = "#{self.connection_options[:uri]}/#{path}"
         body = nil
@@ -78,11 +78,12 @@ module Bright
           body = JSON.dump(params)
         end
         
-        headers = self.headers_for_auth
+        response = connection_retry_wrapper {
+          connection = Bright::Connection.new(uri)
+          headers = self.headers_for_auth
+          connection.request(method, body, headers)
+        }
 
-        connection = Bright::Connection.new(uri)
-        response = connection.request(method, body, headers)
-        
         if !response.error?
           response_hash = JSON.parse(response.body)
         else
@@ -91,55 +92,55 @@ module Bright
         end
         response_hash
       end
-      
+
       protected
-      
+
       def map_student_search_params(attrs)
         attrs
       end
-      
+
       def convert_to_student_data(attrs)
         cattrs = {}
-        
+
         cattrs[:first_name]        = attrs["FirstName"]
         cattrs[:middle_name]       = attrs["MiddleName"]
         cattrs[:last_name]         = attrs["LastName"]
-        
+
         cattrs[:api_id]           = attrs["PermanentID"]
         cattrs[:sis_student_id]   = attrs["StudentNumber"]
         cattrs[:state_student_id] = attrs["StateStudentID"]
-        
+
         cattrs[:gender]           = attrs["Sex"]
         if attrs["Birthdate"]
-          begin 
+          begin
             cattrs[:birth_date] = Date.strptime(attrs["Birthdate"], DATE_FORMAT)
           rescue => e
             puts "#{e.inspect} #{bd}"
           end
         end
-        
+
         #SchoolCode
-        
+
         cattrs.reject{|k,v| v.respond_to?(:empty?) ? v.empty? : v.nil?}
       end
-      
+
       def convert_to_school_data(attrs)
         cattrs = {}
-        
+
         cattrs[:api_id] = attrs["SchoolCode"]
         cattrs[:name] = attrs["Name"]
         cattrs[:number] = attrs["SchoolCode"]
-        
+
         cattrs.reject{|k,v| v.respond_to?(:empty?) ? v.empty? : v.nil?}
       end
-      
+
       def headers_for_auth
         {
             'AERIES-CERT' => self.connection_options[:certificate],
             'Content-Type' => "application/json"
         }
       end
-            
+
     end
   end
 end

--- a/lib/bright/sis_apis/base.rb
+++ b/lib/bright/sis_apis/base.rb
@@ -1,17 +1,17 @@
 module Bright
   module SisApi
     class Base
-      
+
       def filter_students_by_params(students, params)
         total = params[:limit]
         count = 0
         found = []
-  
+
         keys = (Student.attribute_names & params.keys.collect(&:to_sym))
         puts "filtering on #{keys.join(",")}"
         students.each do |student|
           break if total and count >= total
-    
+
           should = (keys).all? do |m|
             student.send(m) =~ Regexp.new(Regexp.escape(params[m]), Regexp::IGNORECASE)
           end
@@ -20,7 +20,33 @@ module Bright
         end
         found
       end
-  
+
+      def connection_retry_wrapper(&block)
+        @retry_attempts = connection_options[:retry_attempts] || 2
+        retries = 0
+        begin
+          yield
+        rescue Bright::ResponseError => e
+          retries += 1
+          if e.server_error? && retries <= @retry_attempts.to_i
+            puts "retrying #{retries}: #{e.class.to_s} - #{e.to_s}"
+            sleep(retries * 3)
+            retry
+          else
+            raise
+          end
+        rescue Errno::ECONNREFUSED, Net::ReadTimeout, EOFError => e
+          retries += 1
+          if retries <= @retry_attempts.to_i
+            puts "retrying #{retries}: #{e.class.to_s} - #{e.to_s}"
+            sleep(retries * 3)
+            retry
+          else
+            raise
+          end
+        end
+      end
+
     end
   end
 end

--- a/lib/bright/sis_apis/base.rb
+++ b/lib/bright/sis_apis/base.rb
@@ -22,13 +22,13 @@ module Bright
       end
 
       def connection_retry_wrapper(&block)
-        @retry_attempts = connection_options[:retry_attempts] || 2
+        retry_attempts = connection_options[:retry_attempts] || 2
         retries = 0
         begin
           yield
         rescue Bright::ResponseError => e
           retries += 1
-          if e.server_error? && retries <= @retry_attempts.to_i
+          if e.server_error? && retries <= retry_attempts.to_i
             puts "retrying #{retries}: #{e.class.to_s} - #{e.to_s}"
             sleep(retries * 3)
             retry
@@ -37,7 +37,7 @@ module Bright
           end
         rescue Errno::ECONNREFUSED, Net::ReadTimeout, EOFError => e
           retries += 1
-          if retries <= @retry_attempts.to_i
+          if retries <= retry_attempts.to_i
             puts "retrying #{retries}: #{e.class.to_s} - #{e.to_s}"
             sleep(retries * 3)
             retry

--- a/lib/bright/sis_apis/bright_sis.rb
+++ b/lib/bright/sis_apis/bright_sis.rb
@@ -108,10 +108,12 @@ module Bright
         else
           body = JSON.dump(params)
         end
-        headers = self.headers_for_auth(uri)
 
-        connection = Bright::Connection.new(uri)
-        response = connection.request(method, body, headers)
+        response = connection_retry_wrapper {
+          connection = Bright::Connection.new(uri)
+          headers = self.headers_for_auth
+          connection.request(method, body, headers)
+        }
 
         if !response.error?
           response_hash = JSON.parse(response.body)

--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -128,10 +128,12 @@ module Bright
         else
           body = JSON.dump(params)
         end
-        headers = self.headers_for_auth(uri)
-
-        connection = Bright::Connection.new(uri)
-        response = connection.request(method, body, headers)
+        
+        response = connection_retry_wrapper {
+          connection = Bright::Connection.new(uri)
+          headers = self.headers_for_auth(uri)
+          connection.request(method, body, headers)
+        }
 
         if !response.error?
           response_hash = JSON.parse(response.body)

--- a/lib/bright/sis_apis/power_school.rb
+++ b/lib/bright/sis_apis/power_school.rb
@@ -159,10 +159,12 @@ module Bright
           body = JSON.dump(params)
         end
 
-        headers = self.headers_for_auth
 
-        connection = Bright::Connection.new(uri)
-        response = connection.request(method, body, headers)
+        response = connection_retry_wrapper {
+          connection = Bright::Connection.new(uri)
+          headers = self.headers_for_auth
+          connection.request(method, body, headers)
+        }
 
         if !response.error?
           response_hash = JSON.parse(response.body)

--- a/lib/bright/sis_apis/skyward.rb
+++ b/lib/bright/sis_apis/skyward.rb
@@ -139,9 +139,11 @@ module Bright
           body = JSON.dump(params)
         end
 
-        headers = self.headers_for_auth
-        connection = Bright::Connection.new(uri)
-        response = connection.request(method, body, headers)
+        response = connection_retry_wrapper {
+          connection = Bright::Connection.new(uri)
+          headers = self.headers_for_auth
+          connection.request(method, body, headers)
+        }
 
         if !response.error?
           response_hash = JSON.parse(response.body)


### PR DESCRIPTION
This moves the retrying logic to the `Base` of `SisApi` so that we can use the subclasses to regenerate authentication headers and whatnot.