### PR TITLE
Add ResponseError#uri

### DIFF
--- a/lib/bright/connection.rb
+++ b/lib/bright/connection.rb
@@ -103,7 +103,7 @@ module Bright
       if @ignore_http_status or !response.error?
         return response
       else
-        raise ResponseError.new(response)
+        raise ResponseError.new(response, endpoint.to_s)
       end
     end
 

--- a/lib/bright/errors.rb
+++ b/lib/bright/errors.rb
@@ -1,10 +1,11 @@
 module Bright
   class ResponseError < StandardError
     attr_reader :response
+    attr_reader :uri
 
-    def initialize(response, message = nil)
+    def initialize(response, uri = nil)
       @response = response
-      @message  = message
+      @uri = uri
     end
 
     def to_s


### PR DESCRIPTION
* Add `ResponseError#uri` so that a developer can optionally capture what the uri being called was that caused an error.