### PR TITLE
Delete the page param in the load_more call for PowerSchool

### DIFF
--- a/lib/bright/sis_apis/power_school.rb
+++ b/lib/bright/sis_apis/power_school.rb
@@ -53,6 +53,7 @@ module Bright
             api = self
             load_more_call = proc { |page|
               # pages start at one, so add a page here
+              params.delete(:page)
               api.get_students(params, {:wrap_in_collection => false, :page => (page + 1)})
             }
 
@@ -123,6 +124,7 @@ module Bright
           api = self
           load_more_call = proc { |page|
             # pages start at one, so add a page here
+            params.delete(:page)
             api.get_schools(params, {:wrap_in_collection => false, :page => (page + 1)})
           }
 

--- a/lib/bright/sis_apis/power_school.rb
+++ b/lib/bright/sis_apis/power_school.rb
@@ -53,8 +53,8 @@ module Bright
             api = self
             load_more_call = proc { |page|
               # pages start at one, so add a page here
-              params.delete(:page)
-              api.get_students(params, {:wrap_in_collection => false, :page => (page + 1)})
+              params[:page] = (page + 1)
+              api.get_students(params, {:wrap_in_collection => false})
             }
 
             ResponseCollection.new({
@@ -124,8 +124,8 @@ module Bright
           api = self
           load_more_call = proc { |page|
             # pages start at one, so add a page here
-            params.delete(:page)
-            api.get_schools(params, {:wrap_in_collection => false, :page => (page + 1)})
+            params[:page] = (page + 1)
+            api.get_schools(params, {:wrap_in_collection => false})
           }
 
           ResponseCollection.new({


### PR DESCRIPTION
So that we don’t just keep using page 1 after it’s been set initially.