### PR TITLE
Skip addresses without a street in PowerSchool

### DIFF
--- a/lib/bright/sis_apis/power_school.rb
+++ b/lib/bright/sis_apis/power_school.rb
@@ -233,7 +233,7 @@ module Bright
 
         #Student Address
         begin
-          cattrs[:addresses] = attrs["addresses"].to_a.collect{|a| self.convert_to_address_data(a)}.uniq{|a| a[:street]} if attrs["addresses"]
+          cattrs[:addresses] = attrs["addresses"].to_a.collect{|a| self.convert_to_address_data(a)}.select{|a| !a[:street].blank?}.uniq{|a| a[:street]} if attrs["addresses"]
         rescue
         end
 


### PR DESCRIPTION
* Select out any addresses that don't have a street attribute