### PR TITLE
Retrieve spelling fix

### DIFF
--- a/lib/bright/sis_apis/power_school.rb
+++ b/lib/bright/sis_apis/power_school.rb
@@ -139,7 +139,7 @@ module Bright
         end
       end
 
-      def retrive_access_token
+      def retrieve_access_token
         connection = Bright::Connection.new("#{self.connection_options[:uri]}/oauth/access_token/")
         response = connection.request(:post, "grant_type=client_credentials", self.headers_for_access_token)
         if !response.error?
@@ -415,7 +415,7 @@ module Bright
       end
 
       def headers_for_auth
-        self.retrive_access_token if self.connection_options[:access_token].nil?
+        self.retrieve_access_token if self.connection_options[:access_token].nil?
         {
           "Authorization" => "Bearer #{self.connection_options[:access_token]}",
           "Accept" => "application/json;charset=UTF-8",

--- a/lib/bright/sis_apis/skyward.rb
+++ b/lib/bright/sis_apis/skyward.rb
@@ -124,7 +124,7 @@ module Bright
         end
         if response_hash["access_token"]
           self.connection_options[:access_token] = response_hash["access_token"]
-          self.connection_options[:access_token_expires] = Time.now + response_hash["expires_in"]
+          self.connection_options[:access_token_expires] = (Time.now - 10) + response_hash["expires_in"]
         end
         response_hash
       end

--- a/lib/bright/sis_apis/skyward.rb
+++ b/lib/bright/sis_apis/skyward.rb
@@ -111,7 +111,7 @@ module Bright
         return guardians
       end
 
-      def retrive_access_token
+      def retrieve_access_token
         connection = Bright::Connection.new("#{self.connection_options[:uri]}/token")
         response = connection.request(:post,
           {"grant_type" => "password",
@@ -262,7 +262,7 @@ module Bright
 
       def headers_for_auth
         if self.connection_options[:access_token].nil? or self.connection_options[:access_token_expires] < Time.now
-          self.retrive_access_token
+          self.retrieve_access_token
         end
         {
           "Authorization" => "Bearer #{self.connection_options[:access_token]}",


### PR DESCRIPTION
* Fix the spelling of `"retrieve"`
* Add a slight buffer to the `access_token_expires` for Skyward access tokens