### PR TITLE
Fix/get call demographics 404 error

### DIFF
--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -339,6 +339,8 @@ module Bright
       def get_demographic_information(api_id)
         demographic_hsh = {}
         demographics_params = self.request(:get, "demographics/#{api_id}")["demographics"]
+        return demographic_hsh if demographics_params.nil?
+
         unless (bday = demographics_params["birthdate"] || demographics_params["birthDate"]).blank?
           demographic_hsh[:birth_date] = Date.parse(bday).to_s
         end

--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -314,7 +314,8 @@ module Bright
         end
 
         #add the demographic information
-        user_data_hsh.merge!(get_demographic_information(user_data_hsh[:api_id]))
+        demographics_hash = get_demographic_information(user_data_hsh[:api_id])
+        user_data_hsh.merge!(demographics_hash) unless demographics_hash.blank?
 
         #if you're a student, build the contacts too
         if bright_type == "Student" and !user_params["agents"].blank?


### PR DESCRIPTION
Sentry Issue # 2500835917

This fixes an error with the demographic endpoint. 
If the demographic endpoint response is a 404, we handle the error response, but the program does not continue execution. 

This makes sure we check the demographics response hash, and return early if the hash is `nil`

