### PR TITLE
Fix/demographics-call-rescue-404

### DIFF
--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -339,8 +339,13 @@ module Bright
 
       def get_demographic_information(api_id)
         demographic_hsh = {}
-        demographics_params = self.request(:get, "demographics/#{api_id}")["demographics"]
-        return demographic_hsh if demographics_params.nil?
+
+        begin
+          demographics_params = request(:get, "demographics/#{api_id}")["demographics"]
+        rescue Bright::ResponseError => e
+          puts e
+          return demographic_hsh
+        end
 
         unless (bday = demographics_params["birthdate"] || demographics_params["birthDate"]).blank?
           demographic_hsh[:birth_date] = Date.parse(bday).to_s

--- a/lib/bright/sis_apis/infinite_campus.rb
+++ b/lib/bright/sis_apis/infinite_campus.rb
@@ -343,8 +343,11 @@ module Bright
         begin
           demographics_params = request(:get, "demographics/#{api_id}")["demographics"]
         rescue Bright::ResponseError => e
-          puts e
-          return demographic_hsh
+          if e.message.to_s.include?('404')
+            return demographic_hsh
+          else
+            raise e
+          end
         end
 
         unless (bday = demographics_params["birthdate"] || demographics_params["birthDate"]).blank?


### PR DESCRIPTION
[Sentry Error](https://sentry.io/organizations/arux-software/issues/3191865299/?project=5177588&query=is%3Aunresolved)

This adds a `begin/rescue` block to the demographics call. If the response is a 404 we rescue the error and return an empty  hash instead of the program crashing. 

**Before**: 
```ruby
campus.get_demographic_information('26C6BF04-488D-40AD-8544-13E0DB7A4C08')
Bright::ResponseError (Failed with 404)
```
program crashes, no further code is executed 

**After**: 
```ruby
campus.get_demographic_information('26C6BF04-488D-40AD-8544-13E0DB7A4C08')
Failed with 404
=> {}
```
an empty hash is returned and it gets handled with the [guard clause here](https://github.com/Arux-Software/Bright/blob/3e747741edad1c586cbdb5ec2b6d9b46d8e2458e/lib/bright/sis_apis/infinite_campus.rb#L318)

If we hit further issues we can try filtering out users in the `get_students` call. Something like this, but we would have to conditional render the `role(s)` key depending on the api version. 
```ruby
students = students_hash.compact.collect do |st_hsh|
  next unless st_hsh['roles'].flat_map(&:values).include?('student')
  Student.new(convert_to_user_data(st_hsh))
end
```

I also tried updating InfiniteCampus#map_search_params to include `when 'roles'` in the case statement, but that broke the whole process of the `get_students` call. 



 