### PR TITLE
Fix/focus-api-threading

### DIFF
--- a/lib/bright/sis_apis/focus.rb
+++ b/lib/bright/sis_apis/focus.rb
@@ -66,7 +66,7 @@ module Bright
             :total => total_results,
             :per_page => params[:limit],
             :load_more_call => load_more_call,
-            :no_threads => options[:no_threads]
+            :no_threads => 2
           })
         else
           students

--- a/lib/bright/sis_apis/focus.rb
+++ b/lib/bright/sis_apis/focus.rb
@@ -10,6 +10,8 @@ module Bright
 
       attr_accessor :connection_options, :schools_cache, :school_years_cache
 
+      DEFAULT_NO_THREADS = 2
+
       DEMOGRAPHICS_CONVERSION = {
         "americanIndianOrAlaskaNative"=>"American Indian Or Alaska Native",
         "asian"=>"Asian",
@@ -66,7 +68,7 @@ module Bright
             :total => total_results,
             :per_page => params[:limit],
             :load_more_call => load_more_call,
-            :no_threads => 2
+            :no_threads => options[:no_threads] || DEFAULT_NO_THREADS
           })
         else
           students


### PR DESCRIPTION
We were hitting a 429 consistently, reducing the thread count from the default of 4, to 2, fixes the problem. This was only an issue for the Focus API. 

I think it makes most sense to hardcode the thread-count into the Focus API (since this is only an issue with that API) instead of conditionally sending a `bright_options` hash from the SIS app based upon what district/sis_setting is being called. 